### PR TITLE
When scanning a Dragonite, script fails because there's no key 'name' on the values array

### DIFF
--- a/ivcheck.py
+++ b/ivcheck.py
@@ -72,7 +72,7 @@ class Main:
             blacklist = False
             state, values = await self.check_pokemon()
 
-            if values["name"] in self.config["blacklist"]:
+            if "name" in values and values["name"] in self.config["blacklist"]:
                 blacklist = True
             elif state == CALCY_SUCCESS:
                 num_errors = 0


### PR DESCRIPTION
I fixed it like so, but I might be completely mistaken and doing something wrong.

Take a quick look at it and tell me if this makes sense or if is this a PEBCAK :grin:

```
$ python ivcheck.py 
2018-10-20 13:36:57,601 - ivcheck - DEBUG - logcat line received: I/ThermalEngine(  732): vs_get_temperature: read[1] tsens_tz_sensor0 53000 mC, weight[1] -1
2018-10-20 13:36:57,602 - ivcheck - DEBUG - logcat line received: D/IntentReceiver(27198): Received intent: tesmath.calcy.ACTION_ANALYZE_SCREEN
2018-10-20 13:36:57,602 - ivcheck - DEBUG - logcat line received: D/MainService(27198): Action: tesmath.calcy.ACTION_ANALYZE_SCREEN
2018-10-20 13:36:57,602 - ivcheck - DEBUG - logcat line received: V/MainService(27198): SilentMode: true
2018-10-20 13:36:57,629 - ivcheck - DEBUG - logcat line received: --------- beginning of system
2018-10-20 13:36:57,629 - ivcheck - DEBUG - logcat line received: I/DisplayManagerService(  899): Display device added: DisplayDeviceInfo{"screen-mirror": uniqueId="virtual:tesmath.calcy,10195,screen-mirror,0", 1080 x 1920, modeId 135, defaultModeId 135, supportedModes [{id=135, width=1080, height=1920, fps=60.0}], colorMode 0, supportedColorModes [0], HdrCapabilities null, density 378, 378.0 x 378.0 dpi, appVsyncOff 0, presDeadline 16666666, touch NONE, rotation 0, type VIRTUAL, state ON, owner tesmath.calcy (uid 10195), FLAG_PRIVATE, FLAG_PRESENTATION}
2018-10-20 13:36:57,656 - ivcheck - DEBUG - logcat line received: I/ActivityManager(  899): Override config changes=5df8 {0.0 ?mcc?mnc ?localeList ?layoutDir sw457dp w457dp h812dp 378dpi nrml long port ?uimode ?night finger -keyb/v/h -nav/h appBounds=Rect(0, 0 - 1080, 1920)} for displayId=134
2018-10-20 13:36:57,679 - ivcheck - DEBUG - logcat line received: E/FrameEvents(  488): Source mDeltas not empty.
2018-10-20 13:36:57,724 - ivcheck - DEBUG - logcat line received: E/FrameEvents(  488): Source mDeltas not empty.
2018-10-20 13:36:57,724 - ivcheck - DEBUG - logcat line received: I/InputReader(  899): Reconfiguring input devices.  changes=0x00000004
2018-10-20 13:36:57,724 - ivcheck - DEBUG - logcat line received: I/zygote  (27198): NativeAlloc concurrent copying GC freed 9891(460KB) AllocSpace objects, 3(60KB) LOS objects, 49% free, 7MB/15MB, paused 589us total 106.562ms
2018-10-20 13:36:57,919 - ivcheck - DEBUG - logcat line received: E/BufferQueueProducer(27198): [ImageReader-1080x1920f1m2-27198-133] dequeueBuffer: BufferQueue has been abandoned
2018-10-20 13:36:57,919 - ivcheck - DEBUG - logcat line received: I/Adreno  (  488): DequeueBuffer: dequeueBuffer failed
2018-10-20 13:36:57,919 - ivcheck - DEBUG - logcat line received: I/DisplayManagerService(  899): Display device removed: DisplayDeviceInfo{"screen-mirror": uniqueId="virtual:tesmath.calcy,10195,screen-mirror,0", 1080 x 1920, modeId 135, defaultModeId 135, supportedModes [{id=135, width=1080, height=1920, fps=60.0}], colorMode 0, supportedColorModes [0], HdrCapabilities null, density 378, 378.0 x 378.0 dpi, appVsyncOff 0, presDeadline 16666666, touch NONE, rotation 0, type VIRTUAL, state ON, owner tesmath.calcy (uid 10195), FLAG_PRIVATE, FLAG_PRESENTATION}
2018-10-20 13:36:57,920 - ivcheck - DEBUG - logcat line received: E/DisplayDevice(  488): eglSwapBuffers(0x1, 0x7b2107e280) failed with 0x0000300d
2018-10-20 13:36:57,920 - ivcheck - DEBUG - logcat line received: I/InputReader(  899): Reconfiguring input devices.  changes=0x00000004
2018-10-20 13:36:57,930 - ivcheck - DEBUG - logcat line received: D/aw      (27198): ********* Analyzing 5 screenshots ***********
2018-10-20 13:36:57,930 - ivcheck - DEBUG - logcat line received: D/aw      (27198): isMonsterScreen: White box confidence: 0.96
2018-10-20 13:36:57,930 - ivcheck - DEBUG - logcat line received: D/aw      (27198): isMonsterScreen: HP-Bar confidence: 1.00
2018-10-20 13:36:57,930 - ivcheck - DEBUG - logcat line received: D/aw      (27198): Detected monster screen
2018-10-20 13:36:57,931 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-Dust: 6000
2018-10-20 13:36:57,931 - ivcheck - DEBUG - logcat line received: D/aw      (27198): Search level: 32.0 (0.845, trainer level: 35)
2018-10-20 13:36:57,931 - ivcheck - DEBUG - logcat line received: D/aw      (27198): Ratio (TLvl+1) for level 32.0 (954.55,586.88): 0.568
2018-10-20 13:36:57,932 - ivcheck - DEBUG - logcat line received: D/aw      (27198): Ratio (TLvl+1) for level 32.5 (955.44,592.59): 0.776
2018-10-20 13:36:57,932 - ivcheck - DEBUG - logcat line received: D/aw      (27198): Did not find better arc-point for trainerLevel+1.
2018-10-20 13:36:57,943 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-CandyName (scaled): DRATINI CANDY
2018-10-20 13:36:57,943 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-CandyName after processing: DRATINI
2018-10-20 13:36:57,943 - ivcheck - DEBUG - logcat line received: D/aw      (27198): Found candy name: Dratini
2018-10-20 13:36:58,013 - ivcheck - DEBUG - logcat line received: E/NotificationService(  899): Suppressing notification from package by user request.
2018-10-20 13:36:58,024 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-HP: 144/144 HP
2018-10-20 13:36:58,062 - ivcheck - DEBUG - logcat line received: W/sh      ( 8321): type=1400 audit(0.0:7781): avc: denied { execute_no_trans } for path="/data/data/com.tnqbegkugmeb.erpcrlqlrub/files/osmcore" dev="sda35" ino=1183708 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:app_data_file:s0:c512,c768 tclass=file permissive=0
2018-10-20 13:36:58,096 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-CP: ᴄ ᴘ2  07
2018-10-20 13:36:58,101 - ivcheck - DEBUG - logcat line received: W/aw      (27198): CP 207 incompatible with HP range 144 - 144, dust cost 6000 or level 32.0, id 148; try other monster of this family or other candy names
2018-10-20 13:36:58,107 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-FastMoveName #0: o Steel Wing
2018-10-20 13:36:58,112 - ivcheck - DEBUG - logcat line received: D/ba      (27198): Levenshtein: best candidate for o Steel Wing is Steel Wing (confidence 0.833)
2018-10-20 13:36:58,129 - ivcheck - DEBUG - logcat line received: D/ThermalEngine(  732): handle_timer_sig: SS Id SKIN-HIGH-FLOOR Read emmc_therm 48000mC, Err -1000mC, SampleCnt 1
2018-10-20 13:36:58,132 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-SpecMoveName #0: o Hyper Beam -
2018-10-20 13:36:58,132 - ivcheck - DEBUG - logcat line received: D/ba      (27198): Levenshtein: best candidate for o Hyper Beam is Hyper Beam (confidence 0.833)
2018-10-20 13:36:58,135 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-Gender: ♀
2018-10-20 13:36:58,167 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-CP: ᴄ ᴘ2 07
2018-10-20 13:36:58,170 - ivcheck - DEBUG - logcat line received: W/aw      (27198): CP 207 incompatible with HP range 144 - 144, dust cost 6000 or level 32.0, id 148; try other monster of this family or other candy names
2018-10-20 13:36:58,242 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-CP: ᴄᴘ 7  07
2018-10-20 13:36:58,292 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-CP: ᴄᴘ  07
2018-10-20 13:36:58,306 - ivcheck - DEBUG - logcat line received: I/ThermalEngine(  732): vs_get_temperature: read[0] tsens_tz_sensor15 53000 mC, weight[0] 1
2018-10-20 13:36:58,310 - ivcheck - DEBUG - logcat line received: I/ThermalEngine(  732): vs_get_temperature: read[1] tsens_tz_sensor0 55000 mC, weight[1] -1
2018-10-20 13:36:58,349 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-CP:
2018-10-20 13:36:58,409 - ivcheck - DEBUG - logcat line received: D/aw      (27198): OCR-CP: ᴄ738687
2018-10-20 13:36:58,409 - ivcheck - DEBUG - logcat line received: E/aw      (27198): java.lang.NumberFormatException: For input string: "78687~" while processing CP:
2018-10-20 13:36:58,410 - ivcheck - DEBUG - logcat line received: E/aw      (27198): For input string: "78687~"
2018-10-20 13:36:58,414 - ivcheck - DEBUG - logcat line received: I/aw      (27198): Screenshot analysis took 514ms
2018-10-20 13:36:58,414 - ivcheck - DEBUG - logcat line received: D/MainService(27198): Received values: Id: 148 (Dragonite), Nr: 149, CP: -1, Max HP: 144, Dust cost: 6000, Level: 32.0, FastMove Steel Wing, SpecialMove Hyper Beam, Gender 2, Level-up false:
2018-10-20 13:36:58,415 - ivcheck - DEBUG - RE_CALCY_IV matched
2018-10-20 13:36:58,554 - ivcheck - DEBUG - logcat line received: D/bd      (27198): setValues() - ID: 148 (Level 32.0), -1 CP, 144 HP, 6000 dust cost
2018-10-20 13:36:58,555 - ivcheck - DEBUG - logcat line received: W/aj      (27198): getValidCombinationsFromLvl() - invalid values: Level 32.0 ; -1 CP ; 144 HP
2018-10-20 13:36:58,555 - ivcheck - DEBUG - logcat line received: W/as      (27198): Scan invalid
2018-10-20 13:36:58,555 - ivcheck - DEBUG - RE_SCAN_INVALID matched, raising CalcyIVError
/usr/lib/python3.7/asyncio/unix_events.py:861: RuntimeWarning: A loop is being detached from a child watcher with pending handlers
  RuntimeWarning)
Traceback (most recent call last):
  File "ivcheck.py", line 302, in <module>
    asyncio.run(Main(args).start())
  File "/usr/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.7/asyncio/base_events.py", line 568, in run_until_complete
    return future.result()
  File "ivcheck.py", line 75, in start
    if values["name"] and values["name"] in self.config["blacklist"]:
KeyError: 'name'```