### PR TITLE
Another renaming scheme, which only adds a prefix in front of Calcy's string

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,36 +1,71 @@
 locations:
-    rename: [539, 936]
+    rename: [530, 880]
     next: [980, 280]
     keyboard_ok: [933, 1085]
     rename_ok: [540, 1050]
-    close_calcy_dialog: [966, 1092]
+    close_calcy_dialog: [880, 1160]
     edit_box: [90, 1090] # only used with --touch-paste
     paste: [483, 1092] # only used with --touch-paste
-    favorite_button: [980, 156]
+    favorite_button: [970, 160]
     favorite_button_box: [960, 142, 1001, 180]
-    pokemon_menu_button: [933, 1777]
-    appraise_button: [934, 1377]
+    pokemon_menu_button: [940, 1700]
+    appraise_button: [940, 1315]
     continue_appraisal: [590, 1770]
     calcy_appraisal_save_button: [855, 1149]
     dismiss_calcy: [555, 1296]
-    appraisal_box: [45, 1664, 1032, 1872]
+    appraisal_box: [45, 1594, 1032, 1792]
 
 waits:
-    next: 0.5
+    next: 0.7
     rename: 0.5
     rename_ok: 1
     pokemon_menu_button: 1
     appraise_button: 1
 
 blacklist:
-    - Charizard
-    - Wailmer
+    - Pidgey
+    - Weedle
+    - Whishmur
+    - Wurmple
+    - Caterpie
 
 actions:
+    - conditions:
+        blacklist: true
+    - conditions:
+        success: false
+      actions:
+        rename: "!FAILED"
+    - conditions:
+        iv:
+        iv_min__eq: 0
+        appraised: false
+      actions:
+        appraise:
+    - conditions:
+        iv:
+        iv_max__ge: 90
+        appraised: false
+        blacklist: false
+      actions:
+        appraise:
+    - conditions:
+        name__in:
+          - Tyranitar
+          - Bagon
+          - Dragonite
+          - Beldum
+          - Dratini
+          - Ralts
+          - Machamp
+        iv_max__lt: 90
+      actions:
+        rename: "•TRADE"
+    - conditions:
+        iv_max__lt: 90
     - actions:
         rename-calcy: # Rename normally
 
-
 iv_regexes:
-    - ^(?P<iv_min>\d+)\-(?P<iv_max>\d+).*$
-    - ^(?P<iv>\d+).*$
+    - ^.[A-z\.]+(?P<iv>\d+) .*$
+    - ^.[A-z\.]+(?P<iv_min>\d+)\-(?P<iv_max>\d+) .*$

--- a/config.yaml
+++ b/config.yaml
@@ -11,8 +11,8 @@ locations:
     pokemon_menu_button: [940, 1700]
     appraise_button: [940, 1315]
     continue_appraisal: [590, 1770]
-    calcy_appraisal_save_button: [855, 1149]
-    dismiss_calcy: [555, 1296]
+    calcy_appraisal_save_button: [880, 920]
+    dismiss_calcy: [870, 1160]
     appraisal_box: [45, 1594, 1032, 1792]
 
 waits:
@@ -23,19 +23,18 @@ waits:
     appraise_button: 1
 
 blacklist:
-    - Pidgey
-    - Weedle
-    - Whishmur
-    - Wurmple
-    - Caterpie
+    -
 
 actions:
-    - conditions:
-        blacklist: true
     - conditions:
         success: false
       actions:
         rename: "!FAILED"
+    - conditions:
+        name__in:
+          - Unown
+      actions:
+        rename: "‽Unown"
     - conditions:
         iv:
         iv_min__eq: 0
@@ -46,7 +45,6 @@ actions:
         iv:
         iv_max__ge: 90
         appraised: false
-        blacklist: false
       actions:
         appraise:
     - conditions:
@@ -67,5 +65,5 @@ actions:
         rename-calcy: # Rename normally
 
 iv_regexes:
-    - ^.[A-z\.]+(?P<iv>\d+) .*$
-    - ^.[A-z\.]+(?P<iv_min>\d+)\-(?P<iv_max>\d+) .*$
+    - ^.+     (?P<iv>\d+)$
+    - ^.+     (?P<iv_min>\d+)\-(?P<iv_max>\d+)$

--- a/config.yaml
+++ b/config.yaml
@@ -1,71 +1,36 @@
 locations:
-    rename: [530, 880]
+    rename: [539, 936]
     next: [980, 280]
     keyboard_ok: [933, 1085]
     rename_ok: [540, 1050]
-    close_calcy_dialog: [880, 1160]
+    close_calcy_dialog: [966, 1092]
     edit_box: [90, 1090] # only used with --touch-paste
     paste: [483, 1092] # only used with --touch-paste
-    favorite_button: [970, 160]
+    favorite_button: [980, 156]
     favorite_button_box: [960, 142, 1001, 180]
-    pokemon_menu_button: [940, 1700]
-    appraise_button: [940, 1315]
+    pokemon_menu_button: [933, 1777]
+    appraise_button: [934, 1377]
     continue_appraisal: [590, 1770]
-    calcy_appraisal_save_button: [890, 910]
+    calcy_appraisal_save_button: [855, 1000]
     dismiss_calcy: [555, 1296]
-    appraisal_box: [45, 1594, 1032, 1792]
+    appraisal_box: [45, 1664, 1032, 1872]
 
 waits:
-    next: 0.7
+    next: 0.5
     rename: 0.5
     rename_ok: 1
     pokemon_menu_button: 1
     appraise_button: 1
 
 blacklist:
-    - Pidgey
-    - Weedle
-    - Whishmur
-    - Wurmple
-    - Caterpie
+    - Charizard
+    - Wailmer
 
 actions:
-    - conditions:
-        blacklist: true
-    - conditions:
-        success: false
-      actions:
-        rename: "!FAILED"
-    - conditions:
-        iv:
-        iv_min__eq: 0
-        appraised: false
-      actions:
-        appraise:
-    - conditions:
-        iv:
-        iv_max__ge: 90
-        appraised: false
-        blacklist: false
-      actions:
-        appraise:
-    - conditions:
-        name__in:
-          - Tyranitar
-          - Bagon
-          - Dragonite
-          - Beldum
-          - Dratini
-          - Ralts
-          - Machamp
-        iv_max__lt: 90
-      actions:
-        rename: "•TRADE"
-    - conditions:
-        iv_max__lt: 90
     - actions:
         rename-calcy: # Rename normally
 
+
 iv_regexes:
-    - ^.[A-z\.]+(?P<iv>\d+) .*$
-    - ^.[A-z\.]+(?P<iv_min>\d+)\-(?P<iv_max>\d+) .*$
+    - ^(?P<iv_min>\d+)\-(?P<iv_max>\d+).*$
+    - ^(?P<iv>\d+).*$

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ locations:
     pokemon_menu_button: [933, 1777]
     appraise_button: [934, 1377]
     continue_appraisal: [590, 1770]
-    calcy_appraisal_save_button: [855, 1149]
+    calcy_appraisal_save_button: [855, 1000]
     dismiss_calcy: [555, 1296]
     appraisal_box: [45, 1664, 1032, 1872]
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ locations:
     pokemon_menu_button: [933, 1777]
     appraise_button: [934, 1377]
     continue_appraisal: [590, 1770]
-    calcy_appraisal_save_button: [855, 1000]
+    calcy_appraisal_save_button: [855, 1149]
     dismiss_calcy: [555, 1296]
     appraisal_box: [45, 1664, 1032, 1872]
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,36 +1,71 @@
 locations:
-    rename: [539, 936]
+    rename: [530, 880]
     next: [980, 280]
     keyboard_ok: [933, 1085]
     rename_ok: [540, 1050]
-    close_calcy_dialog: [966, 1092]
+    close_calcy_dialog: [880, 1160]
     edit_box: [90, 1090] # only used with --touch-paste
     paste: [483, 1092] # only used with --touch-paste
-    favorite_button: [980, 156]
+    favorite_button: [970, 160]
     favorite_button_box: [960, 142, 1001, 180]
-    pokemon_menu_button: [933, 1777]
-    appraise_button: [934, 1377]
+    pokemon_menu_button: [940, 1700]
+    appraise_button: [940, 1315]
     continue_appraisal: [590, 1770]
-    calcy_appraisal_save_button: [855, 1000]
+    calcy_appraisal_save_button: [890, 910]
     dismiss_calcy: [555, 1296]
-    appraisal_box: [45, 1664, 1032, 1872]
+    appraisal_box: [45, 1594, 1032, 1792]
 
 waits:
-    next: 0.5
+    next: 0.7
     rename: 0.5
     rename_ok: 1
     pokemon_menu_button: 1
     appraise_button: 1
 
 blacklist:
-    - Charizard
-    - Wailmer
+    - Pidgey
+    - Weedle
+    - Whishmur
+    - Wurmple
+    - Caterpie
 
 actions:
+    - conditions:
+        blacklist: true
+    - conditions:
+        success: false
+      actions:
+        rename: "!FAILED"
+    - conditions:
+        iv:
+        iv_min__eq: 0
+        appraised: false
+      actions:
+        appraise:
+    - conditions:
+        iv:
+        iv_max__ge: 90
+        appraised: false
+        blacklist: false
+      actions:
+        appraise:
+    - conditions:
+        name__in:
+          - Tyranitar
+          - Bagon
+          - Dragonite
+          - Beldum
+          - Dratini
+          - Ralts
+          - Machamp
+        iv_max__lt: 90
+      actions:
+        rename: "•TRADE"
+    - conditions:
+        iv_max__lt: 90
     - actions:
         rename-calcy: # Rename normally
 
-
 iv_regexes:
-    - ^(?P<iv_min>\d+)\-(?P<iv_max>\d+).*$
-    - ^(?P<iv>\d+).*$
+    - ^.[A-z\.]+(?P<iv>\d+) .*$
+    - ^.[A-z\.]+(?P<iv_min>\d+)\-(?P<iv_max>\d+) .*$

--- a/config.yaml
+++ b/config.yaml
@@ -12,12 +12,12 @@ locations:
     appraise_button: [940, 1315]
     continue_appraisal: [590, 1770]
     calcy_appraisal_save_button: [880, 920]
-    dismiss_calcy: [870, 1160]
+    dismiss_calcy: [540, 900]
     appraisal_box: [45, 1594, 1032, 1792]
 
 waits:
-    next: 0.7
-    rename: 0.5
+    next: 0.9
+    rename: 0.7
     rename_ok: 1
     pokemon_menu_button: 1
     appraise_button: 1
@@ -35,18 +35,18 @@ actions:
           - Unown
       actions:
         rename: "‽Unown"
-    - conditions:
-        iv:
-        iv_min__eq: 0
-        appraised: false
-      actions:
-        appraise:
+    # - conditions:
+    #     iv:
+    #     iv_min__eq: 0
+    #     appraised: false
+    #   actions:
+    #     appraise:
     - conditions:
         iv:
         iv_max__ge: 90
         appraised: false
       actions:
-        appraise:
+        rename-calcy:
     - conditions:
         name__in:
           - Tyranitar

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -128,6 +128,8 @@ class Main:
 
     async def get_data_from_clipboard(self):
         clipboard = await self.p.get_clipboard()
+        logger.debug('Device clipboard is: ' + clipboard)
+        logger.debug('Normalized clipboard is: ' + unicodedata.normalize('NFKD', clipboard))
 
         for iv_regex in self.iv_regexes:
             # unicodedata replaces unicode characters like '¹' (u'\xb9')
@@ -135,6 +137,7 @@ class Main:
             # Works with most (if not all) of CalcyIV's numeric schemes.
             match = iv_regex.match(unicodedata.normalize('NFKD', clipboard))
             if match:
+                logger.debug('Clipboard matched against ' + str(iv_regex))
                 d = match.groupdict()
                 if "iv" in d:
                     d["iv"] = float(d["iv"])

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -71,6 +71,7 @@ class Main:
         while True:
             blacklist = False
             state, values = await self.check_pokemon()
+            await self.p.seek_to_end() # just in case any additional lines are present
 
             if "name" in values and values["name"] in self.config["blacklist"]:
                 blacklist = True

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -103,7 +103,7 @@ class Main:
                 actions = await self.get_actions(values)
                 await self.tap("dismiss_calcy")
 
-            if "rename" in actions or "rename-calcy" in actions:
+            if "rename" in actions or "rename-calcy" in actions or "rename-prefix" in actions:
                 if values["success"] is False:
                     await self.tap('close_calcy_dialog') # it gets in the way
                 await self.tap('rename')
@@ -121,6 +121,17 @@ class Main:
                         await self.tap('paste')
                     else:
                         await self.p.key(279)  # Paste into rename
+                elif "rename-prefix" in actions:
+                    if args.touch_paste:
+                        await self.swipe('edit_box', 600)
+                        await self.tap('paste')
+                    else:
+                        await self.p.key(279)  # Paste into rename
+
+                    await self.p.key('KEYCODE_MOVE_HOME')
+                    await self.p.send_intent("clipper.set", extra_values=[["text", actions["rename-prefix"]]])
+                    await self.p.key(279)  # Paste into beggining of string
+
 
                 await self.tap('keyboard_ok')
                 await self.tap('rename_ok')

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -70,7 +70,6 @@ class Main:
         while True:
             blacklist = False
             state, values = await self.check_pokemon()
-            await self.p.seek_to_end() # just in case any additional lines are present
 
             if values["name"] in self.config["blacklist"]:
                 blacklist = True

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -72,7 +72,7 @@ class Main:
             blacklist = False
             state, values = await self.check_pokemon()
 
-            if values["name"] in self.config["blacklist"]:
+            if "name" in values and values["name"] in self.config["blacklist"]:
                 blacklist = True
             elif state == CALCY_SUCCESS:
                 num_errors = 0

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -92,7 +92,7 @@ class Main:
             if "appraise" in actions:
                 await self.tap("pokemon_menu_button")
                 await self.tap("appraise_button")
-                await self.p.send_intent("tesmath.calcy.ACTION_ANALYZE_SCREEN", "tesmath.calcy/.IntentReceiver", [["silentMode", True]])
+                await self.p.send_intent("tesmath.calcy.ACTION_ANALYZE_SCREEN", "tesmath.calcy/.IntentReceiver", [["silentMode", True], ["--user", self.args.user]])
                 for i in range(0, 3):
                     await self.tap("continue_appraisal")
                 while await self.check_appraising():
@@ -247,7 +247,7 @@ class Main:
         raise Exception("No action matched")
 
     async def check_pokemon(self):
-        await self.p.send_intent("tesmath.calcy.ACTION_ANALYZE_SCREEN", "tesmath.calcy/.IntentReceiver", [["silentMode", True]])
+        await self.p.send_intent("tesmath.calcy.ACTION_ANALYZE_SCREEN", "tesmath.calcy/.IntentReceiver", [["silentMode", True], ["--user", self.args.user]])
         red_bar = False
         values = {}
         while True:
@@ -291,6 +291,8 @@ if __name__ == '__main__':
                         help="Config file location.")
     parser.add_argument('--touch-paste', default=False, action='store_true',
                         help="Use touch instead of keyevent for paste.")
+    parser.add_argument('--user', type=int, default=0,
+                        help="Use a cloned CalcyIV from a different phone user. Useful for sandboxing apps like Island, where you could run two instances simultaneously.")
     parser.add_argument('--pid-name', default=None, type=str,
                         help="Create pid file")
     parser.add_argument('--pid-dir', default=None, type=str,

--- a/pokemonlib.py
+++ b/pokemonlib.py
@@ -115,7 +115,9 @@ class PokemonGo(object):
         for key, value in extra_values:
             if isinstance(value, bool):
                 cmd = cmd + " --ez {} {}".format(key, "true" if value else "false")
-            elif value:
+            elif '--user' in key:
+                cmd = cmd + " --user {}".format(value)
+            else:
                 cmd = cmd + " -e {} {}".format(key, value)
         logger.info("Sending intent: " + cmd)
         await self.run(["adb", "-s", await self.get_device(), "shell", cmd])

--- a/pokemonlib.py
+++ b/pokemonlib.py
@@ -114,7 +114,7 @@ class PokemonGo(object):
             line = await self.read_logcat()
             match = RE_CLIPBOARD_TEXT.match(line)
             if match:
-                logger.INFO("RE_CLIPBOARD_TEXT matched.")
+                logger.info("RE_CLIPBOARD_TEXT matched.")
                 return match.group(1)
 
     async def send_intent(self, intent, package=None, extra_values=[]):

--- a/pokemonlib.py
+++ b/pokemonlib.py
@@ -86,6 +86,14 @@ class PokemonGo(object):
         )
         await self.logcat_task.stdout.readline() # Read and discard the one line as -T 0 doesn't work
 
+    async def seek_to_end(self):
+        # Seek to the end of the file
+        while True:
+            try:
+                task = await asyncio.wait_for(self.logcat_task.stdout.readline(), 0.2)
+            except asyncio.TimeoutError:
+                break
+
     async def read_logcat(self):
         if self.logcat_task.returncode != None:
             logger.error("Logcat process is not running")

--- a/pokemonlib.py
+++ b/pokemonlib.py
@@ -106,6 +106,7 @@ class PokemonGo(object):
             line = await self.read_logcat()
             match = RE_CLIPBOARD_TEXT.match(line)
             if match:
+                logger.INFO("RE_CLIPBOARD_TEXT matched.")
                 return match.group(1)
 
     async def send_intent(self, intent, package=None, extra_values=[]):

--- a/pokemonlib.py
+++ b/pokemonlib.py
@@ -86,14 +86,6 @@ class PokemonGo(object):
         )
         await self.logcat_task.stdout.readline() # Read and discard the one line as -T 0 doesn't work
 
-    async def seek_to_end(self):
-        # Seek to the end of the file
-        while True:
-            try:
-                task = await asyncio.wait_for(self.logcat_task.stdout.readline(), 0.2)
-            except asyncio.TimeoutError:
-                break
-
     async def read_logcat(self):
         if self.logcat_task.returncode != None:
             logger.error("Logcat process is not running")


### PR DESCRIPTION
For me, this adds flexibility as, for example, I don't like to rename all my pokémon to trade simply as `·TRADE`, because there always are going to be some that are worse than others, so I like to keep them together for easy trading (using a prefix), but also have the ability to know what exactly they are (IVs and so on).

Feel free to comment or refuse the PR, it's quite personal and subjective :grin: 

**The only commit that matters is c3078ad.** Everything else is lack of understanding of basic git flow of mine... :unamused: 