### PR TITLE
New action 'rename-prefix'

### DIFF
--- a/ivcheck.py
+++ b/ivcheck.py
@@ -100,7 +100,7 @@ class Main:
                 actions = await self.get_actions(values)
                 await self.tap("dismiss_calcy")
 
-            if "rename" in actions or "rename-calcy" in actions:
+            if "rename" in actions or "rename-calcy" in actions or "rename-prefix" in actions:
                 if values["success"] is False:
                     await self.tap('close_calcy_dialog') # it gets in the way
                 await self.tap('rename')
@@ -118,6 +118,17 @@ class Main:
                         await self.tap('paste')
                     else:
                         await self.p.key(279)  # Paste into rename
+                elif "rename-prefix" in actions:
+                    if args.touch_paste:
+                        await self.swipe('edit_box', 600)
+                        await self.tap('paste')
+                    else:
+                        await self.p.key(279)  # Paste into rename
+
+                    await self.p.key('KEYCODE_MOVE_HOME')
+                    await self.p.send_intent("clipper.set", extra_values=[["text", actions["rename-prefix"]]])
+                    await self.p.key(279)  # Paste into beggining of string
+
 
                 await self.tap('keyboard_ok')
                 await self.tap('rename_ok')


### PR DESCRIPTION
> Now there we go, I learned how to properly do a PR! :grin: 

This adds a new action called rename-prefix, which keeps Calcy renaming scheme but adds a custom text at the beginning, usually a symbol for sorting.

For me, this adds flexibility as, for example, I don't like to rename all my pokémon to trade simply as ·TRADE, because there always are going to be some that are worse than others, so I like to keep them together for easy trading (using a prefix), but also have the ability to know what exactly they are (IVs and so on).

Feel free to comment or refuse the PR, it's quite personal and subjective grin