### PR TITLE
Allows actions 'rename' and 'rename-prefix' to use whitespaces

### DIFF
--- a/pokemonlib.py
+++ b/pokemonlib.py
@@ -118,7 +118,7 @@ class PokemonGo(object):
             elif '--user' in key:
                 cmd = cmd + " --user {}".format(value)
             else:
-                cmd = cmd + " -e {} {}".format(key, value)
+                cmd = cmd + " -e {} '{}'".format(key, value)
         logger.info("Sending intent: " + cmd)
         await self.run(["adb", "-s", await self.get_device(), "shell", cmd])
 


### PR DESCRIPTION
The whitespace problem persisted even after switching to clipper.set, it's just a matter of adding qutoes ;)

This works with or without the rename-prefix PR, it's a fix on pokemonlib