### PR TITLE
Add support for 'get_moves` action

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -14,6 +14,8 @@ locations:
     calcy_appraisal_save_button: [855, 1000]
     dismiss_calcy: [555, 1296]
     appraisal_box: [45, 1664, 1032, 1872]
+    scroll_to_moves: [45, 1864, 45, 1200]
+    scroll_to_top: [45, 1000, 45, 1864]
 
 waits:
     next: 0.5


### PR DESCRIPTION
This adds a new `get_moves` action which will scroll down to the moves part of the screen using a swipe input, trigger calcyiv, and then scroll back up to the top.  The scroll up swipe is slightly longer than the scroll down, because I found that it didn't always scroll completely to the top otherwise.

Note that the config.yaml.example coordinates are for a pocophone and probably don't work on a 1080p phone.