### PR TITLE
Check for blacklist only on success

### DIFF
--- a/ivcheck.py
+++ b/ivcheck.py
@@ -169,10 +169,10 @@ class Main:
             blacklist = False
             state, values = await self.check_pokemon()
 
-            if values["name"] in self.config["blacklist"]:
-                blacklist = True
-            elif state == CALCY_SUCCESS:
+            if state == CALCY_SUCCESS:
                 num_errors = 0
+                if values["name"] in self.config["blacklist"]:
+                    blacklist = True
             elif state == CALCY_RED_BAR:
                 continue
             elif state == CALCY_SCAN_INVALID:


### PR DESCRIPTION
If we couldn't scan the pokemon, we probably don't have the name, and when that happens things crash because there is no name key in the values returned.