### PR TITLE
Fixes a bug that happens sporadically on some scans

### DIFF
--- a/ivcheck.py
+++ b/ivcheck.py
@@ -37,7 +37,7 @@ logger.addHandler(ch)
 RE_CALCY_IV = re.compile(r"^./MainService\(\s*\d+\): Received values: Id: \d+ \((?P<name>.+)\), Nr: (?P<id>\d+), CP: (?P<cp>\-{0,1}\d+), Max HP: (?P<max_hp>\d+), Dust cost: (?P<dust_cost>\d+), Level: (?P<level>\-{0,1}[0-9\.]+), FastMove (?P<fast_move>.+), SpecialMove (?P<special_move>.+),Gender (?P<gender>\-{0,1}\d+), catchYear (?P<catch_year>.+), Level-up (true|false):$")
 RE_RED_BAR = re.compile(r"^.+\(\s*\d+\): Screenshot #\d has red error box at the top of the screen$")
 RE_SUCCESS = re.compile(r"^.+\(\s*\d+\): calculateScanOutputData finished after \d+ms$")
-RE_SCAN_INVALID = re.compile(r"^.+\(\s*\d+\): Scan invalid$")
+RE_SCAN_INVALID = re.compile(r"^.+\(\s*\d+\): Scan invalid .+$")
 
 NAME_MAX_LEN = 12
 


### PR DESCRIPTION
In some cases (don't know which ones) the line from the logcat the we use to identify invalid scans comes with a little extra bit at the end:
`W/az      (15340): Scan invalid (2)`

That makes the script loop forever on the check_pokemon() while loop, and you have no initial idea why, which is the reason this took me an hour and a half to find out lol.