### PR TITLE
Stuck logcats solutions

### DIFF
--- a/ivcheck.py
+++ b/ivcheck.py
@@ -176,7 +176,7 @@ class Main:
                 blacklist = True
             elif state == CALCY_SUCCESS:
                 num_errors = 0
-            elif state in [CALCY_RED_BAR, CALCY_SCAN_TOO_SOON]:
+            elif state in CALCY_RED_BAR:
                 continue
             elif state == CALCY_SCAN_TOO_SOON:
                 num_errors += 1  # uses the same variable as CALCY_SCAN_INVALID, as they'll never happen simultaneously

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -34,7 +34,7 @@ formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(messag
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
-RE_CALCY_IV = re.compile(r"^./MainService\(\s*\d+\): Received values: Id: \d+ \((?P<name>.+)\), Nr: (?P<id>\d+), CP: (?P<cp>\-{0,1}\d+), Max HP: (?P<max_hp>\d+), Dust cost: (?P<dust_cost>\d+), Level: (?P<level>\-{0,1}[0-9\.]+), FastMove (?P<fast_move>.+), SpecialMove (?P<special_move>.+),Gender (?P<gender>\-{0,1}\d+), catchYear (?P<catch_year>.+), Level-up (true|false):$")
+RE_CALCY_IV = re.compile(r"^.\/MainService\(\s*\d+\): Received values: Id: -{0,1}\d+ {0,1}\({0,1}(?P<name>[^\(\)]+){0,1}\){0,1}, Nr: (?P<id>-{0,1}\d+), CP: (?P<cp>-{0,1}\d+), Max HP: (?P<max_hp>-{0,1}\d+), Dust cost: (?P<dust_cost>-{0,1}\d+), Level: (?P<level>\-{0,1}[\d\.]+), FastMove (?P<fast_move>.+), SpecialMove (?P<special_move>.+), SpecialMove2 (?P<special_move2>.+),Gender (?P<gender>\-{0,1}\d+), catchYear (?P<catch_year>.+), Level-up (true|false):$")
 RE_RED_BAR = re.compile(r"^.+\(\s*\d+\): Screenshot #\d has red error box at the top of the screen$")
 RE_SUCCESS = re.compile(r"^.+\(\s*\d+\): calculateScanOutputData finished after \d+ms$")
 RE_SCAN_INVALID = re.compile(r"^.+\(\s*\d+\): Scan invalid .+$")
@@ -78,7 +78,7 @@ def bool_filter(c):
     return False
 
 CALCY_VARIABLES = [
-    ['catch_year', int_filter],
+    ['catch_year', None],
     ['lucky', bool_filter],
     ['attack', int_filter],
     ['defense', int_filter],

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -176,7 +176,7 @@ class Main:
                 blacklist = True
             elif state == CALCY_SUCCESS:
                 num_errors = 0
-            elif state in CALCY_RED_BAR:
+            elif state == CALCY_RED_BAR:
                 continue
             elif state == CALCY_SCAN_TOO_SOON:
                 num_errors += 1  # uses the same variable as CALCY_SCAN_INVALID, as they'll never happen simultaneously


### PR DESCRIPTION
This PR fixes all the _"stuck on logcat"_ issues I've found so far.

It rewrites the *"Received values:"* regex (`RE_CALCY_IV`) to actually work with all of outputs Calcy sends, except for one, in which it doesn't outputs any MainService/Received values on the logcat, which is why I had to add yet another regex (`RE_SCAN_TOO_SOON`) to catch it.

This will bring some benefits for badly configured `waits` as well or poor internet connections, as there are fallbacks taps for when rename_ok button on PoGo's modal doesn't work or delays a lot.

Also, a small test with 368 random pokemons returned no errors whatsoever and no halt of the whole renaming process (it actually halted on a random internet but `RE_SCAN_TOO_SOON` dealt with it like it's supposed to).

Some other low-priority stuff got fixed as well, like SpecialMove2.