### PR TITLE
Hexadecimal digits support. Better copy-calcy*. Little bit of docs. Requires user to redo their copy calcy.

### DIFF
--- a/docs/actions/ACTIONS.md
+++ b/docs/actions/ACTIONS.md
@@ -52,11 +52,13 @@ _For Gboard users, the character in parenthesis indicates which key on Gboard co
 - `‡` _(Inside key `*`)_
 - `•`_
 - `‰`
+- `☀️` _(It's a sun emoji)_
 - `★` _(Inside key `*`)_
 - `♠` _(Inside key `•`)_
 - `♣` _(Inside key `•`)_
 - `♥` _(Inside key `•`)_
 - `♦` _(Inside key `•`)_
+- `✂️` (Emoji)
 - `✓`
 - `∞` _(Inside key `=`)_
 - Numbers
@@ -65,3 +67,10 @@ _For Gboard users, the character in parenthesis indicates which key on Gboard co
 - `Π` _(Inside key `π`)_
 - `π`
 - `Ω` _(Inside key `π`)_
+
+
+### Per device differences
+
+**Characters above with `[A]` or similar at the end means that the order changes depending on the device. Yeah...**
+
+The letter between the brackets is the device's "type" _(more like mood)_, so if your phone follows pattern [A], you should disregard characters labeled as [B]. In other words, it's either one, or the other.

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -45,8 +45,9 @@ NAME_MAX_LEN = 12
 NUMBER_SETS = [
     [chr(9450)] + [chr(i) for i in range(9312, 9332)] + [chr(i) for i in range(12881, 12896)] + [chr(i) for i in range(12977, 12992)],  # white circled digits "⓪"
     [chr(9471)] + [chr(i) for i in range(10102, 10112)] + [chr(i) for i in range(9451, 9461)],  # blank circled digits "⓿"
-    [chr(8304)] + [chr(185)] + [chr(178)] + [chr(179)] + [chr(i) for i in range(8308, 8314)],  # superscripted digits: "¹"
+    [chr(8304)] + [chr(185)] + [chr(178)] + [chr(179)] + [chr(i) for i in range(8308, 8314)],  # superscripted digits: "    "
     [chr(i) for i in range(8320, 8329)]  # subscripted digits: "₁"
+    [chr(i) for i in range(48, 57) + chr(i) for i in range(65, 70)]  # hexadecimal *digits* (yes, they are digits.)
 ]
 
 CALCY_STRING = '\xa0'*NAME_MAX_LEN + '$CatchDate$|$Lucky$|$ATT$|$DEF$|$HP$|$Gender$|$Trade$|$IV%Min$|$IV%Max$|$AttIV$|$DefIV$|$HpIV$|$FaMove$|$SpMove$|$Appraised$|$Legacy$'

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -46,8 +46,8 @@ NUMBER_SETS = [
     [chr(9450)] + [chr(i) for i in range(9312, 9332)] + [chr(i) for i in range(12881, 12896)] + [chr(i) for i in range(12977, 12992)],  # white circled digits "⓪"
     [chr(9471)] + [chr(i) for i in range(10102, 10112)] + [chr(i) for i in range(9451, 9461)],  # blank circled digits "⓿"
     [chr(8304)] + [chr(185)] + [chr(178)] + [chr(179)] + [chr(i) for i in range(8308, 8314)],  # superscripted digits: "    "
-    [chr(i) for i in range(8320, 8329)]  # subscripted digits: "₁"
-    [chr(i) for i in range(48, 57) + chr(i) for i in range(65, 70)]  # hexadecimal *digits* (yes, they are digits.)
+    [chr(i) for i in range(8320, 8329)],  # subscripted digits: "₁"
+    [chr(i) for i in range(48, 57)] + [chr(i) for i in range(65, 70)]  # hexadecimal *digits* (yes, they are digits.)
 ]
 
 CALCY_STRING = '\xa0'*NAME_MAX_LEN + '$CatchDate$|$Lucky$|$ATT$|$DEF$|$HP$|$Gender$|$Trade$|$IV%Min$|$IV%Max$|$AttIV$|$DefIV$|$HpIV$|$FaMove$|$SpMove$|$Appraised$|$Legacy$'

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -49,7 +49,7 @@ NUMBER_SETS = [
     [chr(i) for i in range(8320, 8329)]  # subscripted digits: "₁"
 ]
 
-CALCY_STRING = '\u2003'*NAME_MAX_LEN + '$CatchDate$,$Lucky$,$ATT$,$DEF$,$HP$,$Gender$,$Trade$,$IV%Min$,$IV%Max$,$AttIV$,$DefIV$,$HpIV$,$FaMove$,$SpMove$,$Appraised$,$Legacy$'
+CALCY_STRING = '\xa0'*NAME_MAX_LEN + '$CatchDate$|$Lucky$|$ATT$|$DEF$|$HP$|$Gender$|$Trade$|$IV%Min$|$IV%Max$|$AttIV$|$DefIV$|$HpIV$|$FaMove$|$SpMove$|$Appraised$|$Legacy$'
 
 def gender_filter(c):
     if c == chr(9794):
@@ -245,12 +245,12 @@ class Main:
         clipboard = await self.p.get_clipboard()
 
         try:
-            calcy, data = clipboard.split('\u2003'*NAME_MAX_LEN)
+            calcy, data = clipboard.split('\xa0'*NAME_MAX_LEN)
         except ValueError:
             logger.error('Received clipboard data that does not contain 12 non-breaking spaces, did you run --copy-calcy and paste onto the end of your calcy rename settings? Clipboard data follows')
             logger.error(repr(clipboard))
             raise
-        data = data.split(',')
+        data = data.split('|')
         values = {}
         for i, item in enumerate(CALCY_VARIABLES):
             name, function = item

--- a/ivcheck.py
+++ b/ivcheck.py
@@ -47,7 +47,7 @@ NUMBER_SETS = [
     [chr(9471)] + [chr(i) for i in range(10102, 10112)] + [chr(i) for i in range(9451, 9461)],  # blank circled digits "⓿"
     [chr(8304)] + [chr(185)] + [chr(178)] + [chr(179)] + [chr(i) for i in range(8308, 8314)],  # superscripted digits: "    "
     [chr(i) for i in range(8320, 8329)],  # subscripted digits: "₁"
-    [chr(i) for i in range(48, 57)] + [chr(i) for i in range(65, 70)]  # hexadecimal *digits* (yes, they are digits.)
+    [chr(i) for i in range(48, 58)] + [chr(i) for i in range(65, 71)]  # hexadecimal *digits* (yes, they are digits.)
 ]
 
 CALCY_STRING = '\xa0'*NAME_MAX_LEN + '$CatchDate$|$Lucky$|$ATT$|$DEF$|$HP$|$Gender$|$Trade$|$IV%Min$|$IV%Max$|$AttIV$|$DefIV$|$HpIV$|$FaMove$|$SpMove$|$Appraised$|$Legacy$'


### PR DESCRIPTION
1. Hexadecimal digits support.

2. CALCY_STRING **\***
    - Changing commas for '|' on copy-calcy string (exporting calcy history messes up everything with commas)
    - Changing \u2003 for \xa0 on copy-calcy string (tested: this looks like the best universal nbsp)

3. A bit of more documentation (more characters found).

**\* This requires every user to redo their copy-calcy process. It's for the better good....**

_This is a lot for one PR, but I'm tired... sry._