### PR TITLE
BugFix: values['appraised'] was hardcoded to false, regardless of CalcyIV read values.

### DIFF
--- a/ivcheck.py
+++ b/ivcheck.py
@@ -196,7 +196,7 @@ class Main:
 
             values["success"] = True if state == CALCY_SUCCESS and blacklist is False else False
             values["blacklist"] = blacklist
-            values["appraised"] = False
+            values["appraised"] = True if values["appraised"] is True else False
             actions = await self.get_actions(values)
             if "appraise" in actions:
                 await self.tap("pokemon_menu_button")


### PR DESCRIPTION
This fixes a bug in which an already appraised pokemon would count as not appraised because  values['appraised'] was hardcoded to False instead of reading CalcyIV output values.